### PR TITLE
Allow posterPath to be null

### DIFF
--- a/packages/core/lib/models/app_state/app_startup_state.freezed.dart
+++ b/packages/core/lib/models/app_state/app_startup_state.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
 
 part of 'app_startup_state.dart';
 
@@ -8,6 +8,9 @@ part of 'app_startup_state.dart';
 // **************************************************************************
 
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$AppStartupStateTearOff {
@@ -38,27 +41,31 @@ mixin _$AppStartupState {
     required TResult Function() initializing,
     required TResult Function() needsProfile,
     required TResult Function(ProfilesData profilesData) profileLoaded,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? initializing,
     TResult Function()? needsProfile,
     TResult Function(ProfilesData profilesData)? profileLoaded,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_Initializing value) initializing,
     required TResult Function(_NeedsProfile value) needsProfile,
     required TResult Function(_ProfileLoaded value) profileLoaded,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Initializing value)? initializing,
     TResult Function(_NeedsProfile value)? needsProfile,
     TResult Function(_ProfileLoaded value)? profileLoaded,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -282,7 +289,8 @@ class __$ProfileLoadedCopyWithImpl<$Res>
     return _then(_ProfileLoaded(
       profilesData == freezed
           ? _value.profilesData
-          : profilesData as ProfilesData,
+          : profilesData // ignore: cast_nullable_to_non_nullable
+              as ProfilesData,
     ));
   }
 }
@@ -369,7 +377,8 @@ class _$_ProfileLoaded implements _ProfileLoaded {
 abstract class _ProfileLoaded implements AppStartupState {
   const factory _ProfileLoaded(ProfilesData profilesData) = _$_ProfileLoaded;
 
-  ProfilesData get profilesData;
+  ProfilesData get profilesData => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$ProfileLoadedCopyWith<_ProfileLoaded> get copyWith;
+  _$ProfileLoadedCopyWith<_ProfileLoaded> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/packages/core/lib/models/app_state/create_profile_state.freezed.dart
+++ b/packages/core/lib/models/app_state/create_profile_state.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
 
 part of 'create_profile_state.dart';
 
@@ -8,6 +8,9 @@ part of 'create_profile_state.dart';
 // **************************************************************************
 
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$CreateProfileStateTearOff {
@@ -38,27 +41,31 @@ mixin _$CreateProfileState {
     required TResult Function() noError,
     required TResult Function(String errorText) error,
     required TResult Function() loading,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? noError,
     TResult Function(String errorText)? error,
     TResult Function()? loading,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_NoError value) noError,
     required TResult Function(_Error value) error,
     required TResult Function(_Loading value) loading,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_NoError value)? noError,
     TResult Function(_Error value)? error,
     TResult Function(_Loading value)? loading,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -186,7 +193,10 @@ class __$ErrorCopyWithImpl<$Res> extends _$CreateProfileStateCopyWithImpl<$Res>
     Object? errorText = freezed,
   }) {
     return _then(_Error(
-      errorText == freezed ? _value.errorText : errorText as String,
+      errorText == freezed
+          ? _value.errorText
+          : errorText // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -273,9 +283,9 @@ class _$_Error implements _Error {
 abstract class _Error implements CreateProfileState {
   const factory _Error(String errorText) = _$_Error;
 
-  String get errorText;
+  String get errorText => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$ErrorCopyWith<_Error> get copyWith;
+  _$ErrorCopyWith<_Error> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc

--- a/packages/core/lib/models/app_state/now_playing_state.freezed.dart
+++ b/packages/core/lib/models/app_state/now_playing_state.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
 
 part of 'now_playing_state.dart';
 
@@ -8,6 +8,9 @@ part of 'now_playing_state.dart';
 // **************************************************************************
 
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$NowPlayingStateTearOff {
@@ -44,27 +47,31 @@ mixin _$NowPlayingState {
         data,
     required TResult Function(List<TMDBMovieBasic> movies) dataLoading,
     required TResult Function(String error) error,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(List<TMDBMovieBasic> movies, bool hasReachedMax)? data,
     TResult Function(List<TMDBMovieBasic> movies)? dataLoading,
     TResult Function(String error)? error,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_Data value) data,
     required TResult Function(_DataLoading value) dataLoading,
     required TResult Function(_Error value) error,
-  });
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Data value)? data,
     TResult Function(_DataLoading value)? dataLoading,
     TResult Function(_Error value)? error,
     required TResult orElse(),
-  });
+  }) =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -106,8 +113,14 @@ class __$DataCopyWithImpl<$Res> extends _$NowPlayingStateCopyWithImpl<$Res>
     Object? hasReachedMax = freezed,
   }) {
     return _then(_Data(
-      movies == freezed ? _value.movies : movies as List<TMDBMovieBasic>,
-      hasReachedMax == freezed ? _value.hasReachedMax : hasReachedMax as bool,
+      movies == freezed
+          ? _value.movies
+          : movies // ignore: cast_nullable_to_non_nullable
+              as List<TMDBMovieBasic>,
+      hasReachedMax == freezed
+          ? _value.hasReachedMax
+          : hasReachedMax // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -211,10 +224,10 @@ abstract class _Data implements NowPlayingState {
   const factory _Data(List<TMDBMovieBasic> movies, bool hasReachedMax) =
       _$_Data;
 
-  List<TMDBMovieBasic> get movies;
-  bool get hasReachedMax;
+  List<TMDBMovieBasic> get movies => throw _privateConstructorUsedError;
+  bool get hasReachedMax => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$DataCopyWith<_Data> get copyWith;
+  _$DataCopyWith<_Data> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -241,7 +254,10 @@ class __$DataLoadingCopyWithImpl<$Res>
     Object? movies = freezed,
   }) {
     return _then(_DataLoading(
-      movies == freezed ? _value.movies : movies as List<TMDBMovieBasic>,
+      movies == freezed
+          ? _value.movies
+          : movies // ignore: cast_nullable_to_non_nullable
+              as List<TMDBMovieBasic>,
     ));
   }
 }
@@ -336,9 +352,10 @@ class _$_DataLoading with DiagnosticableTreeMixin implements _DataLoading {
 abstract class _DataLoading implements NowPlayingState {
   const factory _DataLoading(List<TMDBMovieBasic> movies) = _$_DataLoading;
 
-  List<TMDBMovieBasic> get movies;
+  List<TMDBMovieBasic> get movies => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$DataLoadingCopyWith<_DataLoading> get copyWith;
+  _$DataLoadingCopyWith<_DataLoading> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -362,7 +379,10 @@ class __$ErrorCopyWithImpl<$Res> extends _$NowPlayingStateCopyWithImpl<$Res>
     Object? error = freezed,
   }) {
     return _then(_Error(
-      error == freezed ? _value.error : error as String,
+      error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -457,7 +477,7 @@ class _$_Error with DiagnosticableTreeMixin implements _Error {
 abstract class _Error implements NowPlayingState {
   const factory _Error(String error) = _$_Error;
 
-  String get error;
+  String get error => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$ErrorCopyWith<_Error> get copyWith;
+  _$ErrorCopyWith<_Error> get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/core/lib/models/tmdb/tmdb_movie_basic.dart
+++ b/packages/core/lib/models/tmdb/tmdb_movie_basic.dart
@@ -14,7 +14,7 @@ abstract class TMDBMovieBasic with _$TMDBMovieBasic {
     @JsonKey(name: 'vote_average') double? voteAverage,
     required String title,
     double? popularity,
-    @JsonKey(name: 'poster_path') required String posterPath,
+    @JsonKey(name: 'poster_path') required String? posterPath,
     @JsonKey(name: 'original_language') String? originalLanguage,
     @JsonKey(name: 'original_title') String? originalTitle,
     @JsonKey(name: 'genre_ids') List<int>? genreIds,

--- a/packages/core/lib/models/tmdb/tmdb_movie_basic.freezed.dart
+++ b/packages/core/lib/models/tmdb/tmdb_movie_basic.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
 
 part of core;
 
@@ -8,6 +8,10 @@ part of core;
 // **************************************************************************
 
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
 TMDBMovieBasic _$TMDBMovieBasicFromJson(Map<String, dynamic> json) {
   return _TMDBMovieBasic.fromJson(json);
 }
@@ -23,7 +27,7 @@ class _$TMDBMovieBasicTearOff {
       @JsonKey(name: 'vote_average') double? voteAverage,
       required String title,
       double? popularity,
-      @JsonKey(name: 'poster_path') required String posterPath,
+      @JsonKey(name: 'poster_path') required String? posterPath,
       @JsonKey(name: 'original_language') String? originalLanguage,
       @JsonKey(name: 'original_title') String? originalTitle,
       @JsonKey(name: 'genre_ids') List<int>? genreIds,
@@ -60,31 +64,32 @@ const $TMDBMovieBasic = _$TMDBMovieBasicTearOff();
 /// @nodoc
 mixin _$TMDBMovieBasic {
   @JsonKey(name: 'vote_count')
-  int? get voteCount;
-  int get id;
-  bool get video;
+  int? get voteCount => throw _privateConstructorUsedError;
+  int get id => throw _privateConstructorUsedError;
+  bool get video => throw _privateConstructorUsedError;
   @JsonKey(name: 'vote_average')
-  double? get voteAverage;
-  String get title;
-  double? get popularity;
+  double? get voteAverage => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  double? get popularity => throw _privateConstructorUsedError;
   @JsonKey(name: 'poster_path')
-  String get posterPath;
+  String? get posterPath => throw _privateConstructorUsedError;
   @JsonKey(name: 'original_language')
-  String? get originalLanguage;
+  String? get originalLanguage => throw _privateConstructorUsedError;
   @JsonKey(name: 'original_title')
-  String? get originalTitle;
+  String? get originalTitle => throw _privateConstructorUsedError;
   @JsonKey(name: 'genre_ids')
-  List<int>? get genreIds;
+  List<int>? get genreIds => throw _privateConstructorUsedError;
   @JsonKey(name: 'backdrop_path')
-  String? get backdropPath;
-  bool? get adult;
-  String? get overview;
+  String? get backdropPath => throw _privateConstructorUsedError;
+  bool? get adult => throw _privateConstructorUsedError;
+  String? get overview => throw _privateConstructorUsedError;
   @JsonKey(name: 'release_date')
-  String? get releaseDate;
+  String? get releaseDate => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson();
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $TMDBMovieBasicCopyWith<TMDBMovieBasic> get copyWith;
+  $TMDBMovieBasicCopyWith<TMDBMovieBasic> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -99,7 +104,7 @@ abstract class $TMDBMovieBasicCopyWith<$Res> {
       @JsonKey(name: 'vote_average') double? voteAverage,
       String title,
       double? popularity,
-      @JsonKey(name: 'poster_path') String posterPath,
+      @JsonKey(name: 'poster_path') String? posterPath,
       @JsonKey(name: 'original_language') String? originalLanguage,
       @JsonKey(name: 'original_title') String? originalTitle,
       @JsonKey(name: 'genre_ids') List<int>? genreIds,
@@ -136,30 +141,62 @@ class _$TMDBMovieBasicCopyWithImpl<$Res>
     Object? releaseDate = freezed,
   }) {
     return _then(_value.copyWith(
-      voteCount: voteCount == freezed ? _value.voteCount : voteCount as int?,
-      id: id == freezed ? _value.id : id as int,
-      video: video == freezed ? _value.video : video as bool,
-      voteAverage:
-          voteAverage == freezed ? _value.voteAverage : voteAverage as double?,
-      title: title == freezed ? _value.title : title as String,
-      popularity:
-          popularity == freezed ? _value.popularity : popularity as double?,
-      posterPath:
-          posterPath == freezed ? _value.posterPath : posterPath as String,
+      voteCount: voteCount == freezed
+          ? _value.voteCount
+          : voteCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      video: video == freezed
+          ? _value.video
+          : video // ignore: cast_nullable_to_non_nullable
+              as bool,
+      voteAverage: voteAverage == freezed
+          ? _value.voteAverage
+          : voteAverage // ignore: cast_nullable_to_non_nullable
+              as double?,
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      popularity: popularity == freezed
+          ? _value.popularity
+          : popularity // ignore: cast_nullable_to_non_nullable
+              as double?,
+      posterPath: posterPath == freezed
+          ? _value.posterPath
+          : posterPath // ignore: cast_nullable_to_non_nullable
+              as String?,
       originalLanguage: originalLanguage == freezed
           ? _value.originalLanguage
-          : originalLanguage as String?,
+          : originalLanguage // ignore: cast_nullable_to_non_nullable
+              as String?,
       originalTitle: originalTitle == freezed
           ? _value.originalTitle
-          : originalTitle as String?,
-      genreIds: genreIds == freezed ? _value.genreIds : genreIds as List<int>?,
+          : originalTitle // ignore: cast_nullable_to_non_nullable
+              as String?,
+      genreIds: genreIds == freezed
+          ? _value.genreIds
+          : genreIds // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
       backdropPath: backdropPath == freezed
           ? _value.backdropPath
-          : backdropPath as String?,
-      adult: adult == freezed ? _value.adult : adult as bool?,
-      overview: overview == freezed ? _value.overview : overview as String?,
-      releaseDate:
-          releaseDate == freezed ? _value.releaseDate : releaseDate as String?,
+          : backdropPath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      adult: adult == freezed
+          ? _value.adult
+          : adult // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      overview: overview == freezed
+          ? _value.overview
+          : overview // ignore: cast_nullable_to_non_nullable
+              as String?,
+      releaseDate: releaseDate == freezed
+          ? _value.releaseDate
+          : releaseDate // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -178,7 +215,7 @@ abstract class _$TMDBMovieBasicCopyWith<$Res>
       @JsonKey(name: 'vote_average') double? voteAverage,
       String title,
       double? popularity,
-      @JsonKey(name: 'poster_path') String posterPath,
+      @JsonKey(name: 'poster_path') String? posterPath,
       @JsonKey(name: 'original_language') String? originalLanguage,
       @JsonKey(name: 'original_title') String? originalTitle,
       @JsonKey(name: 'genre_ids') List<int>? genreIds,
@@ -217,30 +254,62 @@ class __$TMDBMovieBasicCopyWithImpl<$Res>
     Object? releaseDate = freezed,
   }) {
     return _then(_TMDBMovieBasic(
-      voteCount: voteCount == freezed ? _value.voteCount : voteCount as int?,
-      id: id == freezed ? _value.id : id as int,
-      video: video == freezed ? _value.video : video as bool,
-      voteAverage:
-          voteAverage == freezed ? _value.voteAverage : voteAverage as double?,
-      title: title == freezed ? _value.title : title as String,
-      popularity:
-          popularity == freezed ? _value.popularity : popularity as double?,
-      posterPath:
-          posterPath == freezed ? _value.posterPath : posterPath as String,
+      voteCount: voteCount == freezed
+          ? _value.voteCount
+          : voteCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      video: video == freezed
+          ? _value.video
+          : video // ignore: cast_nullable_to_non_nullable
+              as bool,
+      voteAverage: voteAverage == freezed
+          ? _value.voteAverage
+          : voteAverage // ignore: cast_nullable_to_non_nullable
+              as double?,
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      popularity: popularity == freezed
+          ? _value.popularity
+          : popularity // ignore: cast_nullable_to_non_nullable
+              as double?,
+      posterPath: posterPath == freezed
+          ? _value.posterPath
+          : posterPath // ignore: cast_nullable_to_non_nullable
+              as String?,
       originalLanguage: originalLanguage == freezed
           ? _value.originalLanguage
-          : originalLanguage as String?,
+          : originalLanguage // ignore: cast_nullable_to_non_nullable
+              as String?,
       originalTitle: originalTitle == freezed
           ? _value.originalTitle
-          : originalTitle as String?,
-      genreIds: genreIds == freezed ? _value.genreIds : genreIds as List<int>?,
+          : originalTitle // ignore: cast_nullable_to_non_nullable
+              as String?,
+      genreIds: genreIds == freezed
+          ? _value.genreIds
+          : genreIds // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
       backdropPath: backdropPath == freezed
           ? _value.backdropPath
-          : backdropPath as String?,
-      adult: adult == freezed ? _value.adult : adult as bool?,
-      overview: overview == freezed ? _value.overview : overview as String?,
-      releaseDate:
-          releaseDate == freezed ? _value.releaseDate : releaseDate as String?,
+          : backdropPath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      adult: adult == freezed
+          ? _value.adult
+          : adult // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      overview: overview == freezed
+          ? _value.overview
+          : overview // ignore: cast_nullable_to_non_nullable
+              as String?,
+      releaseDate: releaseDate == freezed
+          ? _value.releaseDate
+          : releaseDate // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -285,7 +354,7 @@ class _$_TMDBMovieBasic implements _TMDBMovieBasic {
   final double? popularity;
   @override
   @JsonKey(name: 'poster_path')
-  final String posterPath;
+  final String? posterPath;
   @override
   @JsonKey(name: 'original_language')
   final String? originalLanguage;
@@ -392,7 +461,7 @@ abstract class _TMDBMovieBasic implements TMDBMovieBasic {
       @JsonKey(name: 'vote_average') double? voteAverage,
       required String title,
       double? popularity,
-      @JsonKey(name: 'poster_path') required String posterPath,
+      @JsonKey(name: 'poster_path') required String? posterPath,
       @JsonKey(name: 'original_language') String? originalLanguage,
       @JsonKey(name: 'original_title') String? originalTitle,
       @JsonKey(name: 'genre_ids') List<int>? genreIds,
@@ -406,41 +475,42 @@ abstract class _TMDBMovieBasic implements TMDBMovieBasic {
 
   @override
   @JsonKey(name: 'vote_count')
-  int? get voteCount;
+  int? get voteCount => throw _privateConstructorUsedError;
   @override
-  int get id;
+  int get id => throw _privateConstructorUsedError;
   @override
-  bool get video;
+  bool get video => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'vote_average')
-  double? get voteAverage;
+  double? get voteAverage => throw _privateConstructorUsedError;
   @override
-  String get title;
+  String get title => throw _privateConstructorUsedError;
   @override
-  double? get popularity;
+  double? get popularity => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'poster_path')
-  String get posterPath;
+  String? get posterPath => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'original_language')
-  String? get originalLanguage;
+  String? get originalLanguage => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'original_title')
-  String? get originalTitle;
+  String? get originalTitle => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'genre_ids')
-  List<int>? get genreIds;
+  List<int>? get genreIds => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'backdrop_path')
-  String? get backdropPath;
+  String? get backdropPath => throw _privateConstructorUsedError;
   @override
-  bool? get adult;
+  bool? get adult => throw _privateConstructorUsedError;
   @override
-  String? get overview;
+  String? get overview => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'release_date')
-  String? get releaseDate;
+  String? get releaseDate => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
-  _$TMDBMovieBasicCopyWith<_TMDBMovieBasic> get copyWith;
+  _$TMDBMovieBasicCopyWith<_TMDBMovieBasic> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/packages/core/lib/models/tmdb/tmdb_movie_basic.g.dart
+++ b/packages/core/lib/models/tmdb/tmdb_movie_basic.g.dart
@@ -14,7 +14,7 @@ _$_TMDBMovieBasic _$_$_TMDBMovieBasicFromJson(Map<String, dynamic> json) {
     voteAverage: (json['vote_average'] as num?)?.toDouble(),
     title: json['title'] as String,
     popularity: (json['popularity'] as num?)?.toDouble(),
-    posterPath: json['poster_path'] as String,
+    posterPath: json['poster_path'] as String?,
     originalLanguage: json['original_language'] as String?,
     originalTitle: json['original_title'] as String?,
     genreIds:

--- a/packages/core/lib/models/tmdb/tmdb_movies_response.freezed.dart
+++ b/packages/core/lib/models/tmdb/tmdb_movies_response.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
 
 part of core;
 
@@ -8,6 +8,10 @@ part of core;
 // **************************************************************************
 
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
 TMDBMoviesResponse _$TMDBMoviesResponseFromJson(Map<String, dynamic> json) {
   return _TMDBMoviesResponse.fromJson(json);
 }
@@ -41,17 +45,18 @@ const $TMDBMoviesResponse = _$TMDBMoviesResponseTearOff();
 
 /// @nodoc
 mixin _$TMDBMoviesResponse {
-  int get page;
-  List<TMDBMovieBasic> get results;
+  int get page => throw _privateConstructorUsedError;
+  List<TMDBMovieBasic> get results => throw _privateConstructorUsedError;
   @JsonKey(name: 'total_results')
-  int get totalResults;
+  int get totalResults => throw _privateConstructorUsedError;
   @JsonKey(name: 'total_pages')
-  int get totalPages;
-  List<String> get errors;
+  int get totalPages => throw _privateConstructorUsedError;
+  List<String> get errors => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson();
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $TMDBMoviesResponseCopyWith<TMDBMoviesResponse> get copyWith;
+  $TMDBMoviesResponseCopyWith<TMDBMoviesResponse> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -85,13 +90,26 @@ class _$TMDBMoviesResponseCopyWithImpl<$Res>
     Object? errors = freezed,
   }) {
     return _then(_value.copyWith(
-      page: page == freezed ? _value.page : page as int,
-      results:
-          results == freezed ? _value.results : results as List<TMDBMovieBasic>,
-      totalResults:
-          totalResults == freezed ? _value.totalResults : totalResults as int,
-      totalPages: totalPages == freezed ? _value.totalPages : totalPages as int,
-      errors: errors == freezed ? _value.errors : errors as List<String>,
+      page: page == freezed
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+      results: results == freezed
+          ? _value.results
+          : results // ignore: cast_nullable_to_non_nullable
+              as List<TMDBMovieBasic>,
+      totalResults: totalResults == freezed
+          ? _value.totalResults
+          : totalResults // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: totalPages == freezed
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      errors: errors == freezed
+          ? _value.errors
+          : errors // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ));
   }
 }
@@ -131,13 +149,26 @@ class __$TMDBMoviesResponseCopyWithImpl<$Res>
     Object? errors = freezed,
   }) {
     return _then(_TMDBMoviesResponse(
-      page: page == freezed ? _value.page : page as int,
-      results:
-          results == freezed ? _value.results : results as List<TMDBMovieBasic>,
-      totalResults:
-          totalResults == freezed ? _value.totalResults : totalResults as int,
-      totalPages: totalPages == freezed ? _value.totalPages : totalPages as int,
-      errors: errors == freezed ? _value.errors : errors as List<String>,
+      page: page == freezed
+          ? _value.page
+          : page // ignore: cast_nullable_to_non_nullable
+              as int,
+      results: results == freezed
+          ? _value.results
+          : results // ignore: cast_nullable_to_non_nullable
+              as List<TMDBMovieBasic>,
+      totalResults: totalResults == freezed
+          ? _value.totalResults
+          : totalResults // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: totalPages == freezed
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      errors: errors == freezed
+          ? _value.errors
+          : errors // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ));
   }
 }
@@ -226,18 +257,19 @@ abstract class _TMDBMoviesResponse implements TMDBMoviesResponse {
       _$_TMDBMoviesResponse.fromJson;
 
   @override
-  int get page;
+  int get page => throw _privateConstructorUsedError;
   @override
-  List<TMDBMovieBasic> get results;
+  List<TMDBMovieBasic> get results => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'total_results')
-  int get totalResults;
+  int get totalResults => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: 'total_pages')
-  int get totalPages;
+  int get totalPages => throw _privateConstructorUsedError;
   @override
-  List<String> get errors;
+  List<String> get errors => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
-  _$TMDBMoviesResponseCopyWith<_TMDBMoviesResponse> get copyWith;
+  _$TMDBMoviesResponseCopyWith<_TMDBMoviesResponse> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/packages/core/lib/ui/poster_tile.dart
+++ b/packages/core/lib/ui/poster_tile.dart
@@ -10,7 +10,7 @@ class PosterTile extends StatelessWidget {
     this.debugIndex,
     this.favouriteBuilder,
   });
-  final String imagePath;
+  final String? imagePath;
   final int? debugIndex;
   final WidgetBuilder? favouriteBuilder;
 
@@ -63,17 +63,17 @@ class TopGradient extends StatelessWidget {
 
 class _Poster extends StatelessWidget {
   const _Poster({required this.imagePath});
-  final String imagePath;
+  final String? imagePath;
 
   @override
   Widget build(BuildContext context) {
-    //if (imagePath != null) {
-    return FadeInImage.memoryNetwork(
-      placeholder: kTransparentImage,
-      image: TMDBApi.imageUrl(imagePath, PosterSize.w154),
-      fit: BoxFit.fitWidth,
-    );
-    //}
-    //return Image.memory(kTransparentImage);
+    if (imagePath != null) {
+      return FadeInImage.memoryNetwork(
+        placeholder: kTransparentImage,
+        image: TMDBApi.imageUrl(imagePath!, PosterSize.w154),
+        fit: BoxFit.fitWidth,
+      );
+    }
+    return Image.memory(kTransparentImage);
   }
 }


### PR DESCRIPTION
posterPath can be null. It happens on page 8 when scrolling. The result is a "'Null' is not a subtype of type 'String'". This pull request change the model file and necessary widgets. BTW: Andrea, thank you very much for a very good example of state management! You are awesome!